### PR TITLE
Option to not bump test stats with successful lint checks and optional, more specific names for config environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ gulp.src(['js/**/*.js'])
 
 ### Output
 
-By default, the reporter writes to `eslint.json`. The file name can be changed by setting the `ESLINT_FILE` environment variable.
-Warnings are not reported by default. If you want to report warnings as errors, set the environment variable `ESLINT_WARNING_AS_ERROR`.
+By default, the reporter writes to `eslint.json`. The file name can be changed by setting the `ESLINT_FILE` or `ESLINT_BAMBOO_REPORT_FILE` environment variable.
+Warnings are not reported by default. If you want to report warnings as errors, set the environment variable `ESLINT_BAMBOO_REPORT_WARNING_AS_ERROR`.
+
+By default bamboo's report's test count will increase for every lint check that
+passes. If you prefer to increase the test count for failed checks only, you can set the environment variable `ESLINT_BAMBOO_REPORT_IGNORE_SUCCESS`
 
 ## License
 

--- a/reporter.js
+++ b/reporter.js
@@ -37,7 +37,7 @@ module.exports = function reporter(results) {
       });
     } else {
       output.stats.passes += ignoreSuccess ? 0 : 1;
-      output.passes.push({
+      ignoreSuccess || output.passes.push({
         title: path.basename(result.filePath),
         fullTitle: result.filePath,
         duration: 0,

--- a/reporter.js
+++ b/reporter.js
@@ -2,8 +2,9 @@ var fs = require('fs');
 var path = require('path');
 var util = require('./util');
 
-var filename = process.env.ESLINT_FILE || 'eslint.json';
+var filename = process.env.ESLINT_FILE || process.env.ESLINT_BAMBOO_REPORT_FILE || 'eslint.json';
 var warningAsError = process.env.ESLINT_WARNING_AS_ERROR || false;
+var ignoreSuccess = process.env.ESLINT_BAMBOO_REPORT_IGNORE_SUCESS || false;
 
 module.exports = function reporter(results) {
   var output = {
@@ -23,7 +24,7 @@ module.exports = function reporter(results) {
   results.forEach(function iterator(result) {
     var errorCount = warningAsError ? (result.errorCount + result.warningCount) : result.errorCount;
 
-    output.stats.tests++;
+    output.stats.tests += ignoreSuccess && !errorCount ? 0 : 1;
 
     if (errorCount) {
       output.stats.failures++;
@@ -35,7 +36,7 @@ module.exports = function reporter(results) {
         error: util.format(result),
       });
     } else {
-      output.stats.passes++;
+      output.stats.passes += ignoreSuccess ? 0 : 1;
       output.passes.push({
         title: path.basename(result.filePath),
         fullTitle: result.filePath,

--- a/reporter.js
+++ b/reporter.js
@@ -3,8 +3,8 @@ var path = require('path');
 var util = require('./util');
 
 var filename = process.env.ESLINT_FILE || process.env.ESLINT_BAMBOO_REPORT_FILE || 'eslint.json';
-var warningAsError = process.env.ESLINT_WARNING_AS_ERROR || false;
-var ignoreSuccess = process.env.ESLINT_BAMBOO_REPORT_IGNORE_SUCESS || false;
+var warningAsError = process.env.ESLINT_WARNING_AS_ERROR || process.env.ESLINT_BAMBOO_REPORT_WARNING_AS_ERROR || false;
+var ignoreSuccess = process.env.ESLINT_BAMBOO_REPORT_IGNORE_SUCCESS || false;
 
 module.exports = function reporter(results) {
   var output = {


### PR DESCRIPTION
When there is a lint issue, I'd like to add it as a failed test. But when there are lint issues, bumping the count of "passed tests" seem not very good to me.

I think it's feasible to assume that other people might feel the same, so this PR make ignoring successful lint results an option in this module.

Please note that if you merge this PR, you'll probably want to bump the npm version and publish the version to npm as well.